### PR TITLE
use the scheduled-ecs-task module to make the role least-privilege

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.72.1"
-  constraints = "~> 5.0"
+  constraints = ">= 5.0.0, ~> 5.0, < 6.0.0"
   hashes = [
+    "h1:BkYfMmqLJIqLkLLz9sDRWJR5+7GCXTocNPN4pIHkhQo=",
     "h1:jhd5O5o0CfZCNEwwN0EiDAzb7ApuFrtxJqa6HXW4EKE=",
     "zh:0dea6843836e926d33469b48b948744079023816d16a2ff7666bcfb6aa3522d4",
     "zh:195fa9513f75800a0d62797ebec75ee73e9b8c28d713fe9b63d3b1d1eec129b3",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.0"
   hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",

--- a/main.tf
+++ b/main.tf
@@ -52,78 +52,14 @@ resource "aws_ecs_task_definition" "this" {
   network_mode          = "bridge"
 }
 
-/*
- * Create role for scheduled running of backup task definitions.
- */
-resource "aws_iam_role" "ecs_events" {
-  name = "ecs_events-${local.app_name_and_env}"
+module "task" {
+  source  = "sil-org/scheduled-ecs-task/aws"
+  version = "~> 1.0"
 
-  assume_role_policy = <<DOC
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "events.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-DOC
-
-}
-
-resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
-  name = "ecs_events_run_task_with_any_role"
-  role = aws_iam_role.ecs_events.id
-
-  policy = <<DOC
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "iam:PassRole",
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "ecs:RunTask",
-            "Resource": "${aws_ecs_task_definition.this.arn_without_revision}:*"
-        }
-    ]
-}
-DOC
-
-}
-
-/*
- * CloudWatch configuration to start file system backup.
- */
-resource "aws_cloudwatch_event_rule" "this" {
-  name                = local.app_name_and_env
-  description         = "Start YouTrack backup on cron schedule"
-  is_enabled          = var.backup_enabled
-  schedule_expression = "cron(${var.backup_schedule})"
-
-  tags = {
-    app_name = var.app_name
-    app_env  = local.app_env
-  }
-}
-
-resource "aws_cloudwatch_event_target" "b2_backup" {
-  target_id = "run-${local.app_name_and_env}"
-  rule      = aws_cloudwatch_event_rule.this.name
-  arn       = local.ecs_cluster_arn
-  role_arn  = aws_iam_role.ecs_events.arn
-
-  ecs_target {
-    task_count          = 1
-    launch_type         = "EC2"
-    task_definition_arn = aws_ecs_task_definition.this.arn
-  }
+  name                   = local.app_name_and_env
+  event_rule_description = "Start YouTrack backup on cron schedule"
+  enable                 = var.backup_enabled
+  event_schedule         = "cron(${var.backup_schedule})"
+  ecs_cluster_arn        = local.ecs_cluster_arn
+  task_definition_arn    = aws_ecs_task_definition.this.arn
 }


### PR DESCRIPTION
[ITSE-2843](https://support.gtis.sil.org/issue/ITSE-2843) Restrict roles on all iam:PassRole policies

### Security
- Replace `aws_cloudwatch_*` (Event Bridge) resources and `aws_iam_*` resources with scheduled-ecs-task module, which restricts the `iam:PassRole` to allow only the necessary roles.