### PR TITLE
Remove aws access key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,14 +44,6 @@ locals {
         value = var.app_name
       },
       {
-        name  = "AWS_ACCESS_KEY_ID"
-        value = var.aws_access_key
-      },
-      {
-        name  = "AWS_SECRET_ACCESS_KEY"
-        value = var.aws_secret_key
-      },
-      {
         name  = "AWS_REGION"
         value = var.aws_region
       },


### PR DESCRIPTION
[ITSE-2846](https://support.gtis.sil.org/issue/ITSE-2846) use a task role in youtrack-backup-terraform

---

### Removed
- Removed the AWS access key since it's not used by youtrack-backup script.